### PR TITLE
Fixed missing semicolon error reported by bison 3.0.2

### DIFF
--- a/packages/libs/libpbc/patches/02_missing_semicolon_y.patch
+++ b/packages/libs/libpbc/patches/02_missing_semicolon_y.patch
@@ -1,0 +1,11 @@
+--- libpbc-0.5.12_orig/pbc/parser.y	2014-11-25 15:20:10.016187119 +0100
++++ libpbc-0.5.12/pbc/parser.y	2014-11-25 15:20:18.576187196 +0100
+@@ -81,7 +81,7 @@ expr
+ // Not quite atoms.
+ molecule
+   : molecule LPAR exprlist RPAR  { $$ = $3; tree_set_fun($$, $1); }
+-  | LPAR expr RPAR               { $$ = $2 }
++  | LPAR expr RPAR               { $$ = $2; }
+   | ID
+   ;
+ 


### PR DESCRIPTION
Hi,
This patch fixes the build of libpbc for raspberry pi using ubuntu 14.04 as the host.
Cheers,
Ivan
