### PR TITLE
Fixed missing semicolon error reported by bison 3.0.2

### DIFF
--- a/packages/libs/libpbc/patches/02_missing_semicolon_y.patch
+++ b/packages/libs/libpbc/patches/02_missing_semicolon_y.patch
@@ -1,0 +1,11 @@
+--- libpbc-0.5.12_orig/pbc/parser.y	2014-11-27 22:08:30.594833008 +0100
++++ libpbc-0.5.12/pbc/parser.y	2014-11-27 22:08:45.390030608 +0100
+@@ -81,7 +81,7 @@ expr
+ // Not quite atoms.
+ molecule
+   : molecule LPAR exprlist RPAR  { $$ = $3; tree_set_fun($$, $1); }
+-  | LPAR expr RPAR               { $$ = $2 }
++  | LPAR expr RPAR               { $$ = $2; }
+   | ID
+   ;
+ 


### PR DESCRIPTION
Hi Tom,
This is a remake of my last pull request, I got confused with the last one, sorry.
Same configuration: host ubuntu 14.04 cross compiling openbricks for my raspberry pi.
Ivan
