### PR TITLE
fuse: change download url

### DIFF
--- a/packages/filesystem/fuse/meta
+++ b/packages/filesystem/fuse/meta
@@ -1,6 +1,8 @@
 PKG_NAME=fuse
 PKG_VERSION=2.9.3
-PKG_URL="$SFNET_SRCS/fuse/fuse-${PKG_VERSION}.tar.gz"
+#2.9.4 "release" includes both the current FUSE version (2.9.4) and tarballs for all prior releases. The folder for 2.9.3 not exist
+#PKG_URL="https://github.com/libfuse/libfuse/releases/download/${PKG_NAME}_${PKG_VERSION//./_}/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="https://github.com/libfuse/libfuse/releases/download/${PKG_NAME}_2_9_4/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_REV=1
 PKG_RUN_DEPENDS="$TARGET_LIBC"
 PKG_BUILD_DEPENDS="toolchain"


### PR DESCRIPTION
Sourceforge link no longer works.
I have updated the URL based on this commit.
https://github.com/libfuse/libfuse/commit/579c3b03f57856e369fd6db2226b77aba63b59ff

Please consider update fuse to the last available version (2.9.4)