### PR TITLE
Unpack - move all files, including hidden files

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -91,18 +91,15 @@ fi
 
 # move the extracted files up one level
 PKGTMPDIR=`find $PKG_BUILD_DIR -maxdepth 1 -type d ! -wholename $PKG_BUILD_DIR`
-if [ -d "$PKGTMPDIR" ] && [ "$PKGTMPDIR" != "." ] && [ "$PKGTMPDIR" != ".." ]; then
-  # warning: this will skip dotfiles (usually stuff like .cvsignore)
-  mv "$PKGTMPDIR"/* $PKG_BUILD_DIR
-  [ -d "$PKGTMPDIR/.git" ] && mv "$PKGTMPDIR/.git" $PKG_BUILD_DIR
-  [ -d "$PKGTMPDIR/.svn" ] && mv "$PKGTMPDIR/.svn" $PKG_BUILD_DIR
-  # explicitly copy over .auto directory as some packages (e.g. libdvdcss)
-  # require it
-  [ -d "$PKGTMPDIR/.auto" ] && mv "$PKGTMPDIR/.auto" $PKG_BUILD_DIR
-  # explicitly copy over .local-symbols file as some packages (e.g. linux-backports)
-  # require it
-  [ -f "$PKGTMPDIR/.local-symbols" ] && cp "$PKGTMPDIR/.local-symbols" $PKG_BUILD_DIR
-  rm -rf "$PKGTMPDIR"
+if [ -d "$PKGTMPDIR" ] && [ "$PKGTMPDIR" != "." -a "$PKGTMPDIR" != ".." ]; then
+  # in order to move all files (including hidden files), we must list directory contents first
+  PKGTMPCONTENTS=`ls -A $PKGTMPDIR`
+  for PKGTMPSINGLEITEM in $PKGTMPCONTENTS
+  do
+    # move every single file individually
+    mv "$PKGTMPDIR/$PKGTMPSINGLEITEM" $PKG_BUILD_DIR
+  done
+  rm -rf $PKGTMPDIR
 fi
 
 for srcdir in \


### PR DESCRIPTION
I was having problems with some packages (can't remember the name) and I discovered that there was a hidden directory/file (starting with a dot) that was causing issues, so I tried to improve unpacking script a little bit. This now works fine on my machine (Arch Linux).